### PR TITLE
Rename ViewStore -> Store

### DIFF
--- a/src/Store.ts
+++ b/src/Store.ts
@@ -1,8 +1,8 @@
-import { IAction, IViewStore } from "./types";
+import { IAction, IStore } from "./types";
 import { Chain } from "./utils/Chain";
 import { defer } from "./utils/defer";
 
-export class ViewStore<S> implements IViewStore<S> {
+export class Store<S> implements IStore<S> {
   private chain = new Chain();
 
   public constructor(public state: S, public dispatch: (action: IAction) => void) {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { Emitter } from "./Emitter";
 export { defineAction, off, on, once, take } from "./functions";
-export { IAction, IActionDefinition, IActionType, IEmitter, IViewStore } from "./types";
-export { ViewStore } from "./ViewStore";
+export { IAction, IActionDefinition, IActionType, IEmitter, IStore } from "./types";
+export { Store } from "./Store";

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,7 +23,7 @@ export interface IEmitter {
   off<T>(type: IActionType<T>, handler: (payload: T) => void): void;
 }
 
-export interface IViewStore<S> {
+export interface IStore<S> {
   readonly state: S;
 
   getState(): S;


### PR DESCRIPTION
The original "ViewStore" naming was meant to point out that applications are free to put data in other state containers, but use this one just for React/Redux stuff, but that's probably more obfuscating than clarifying.