### PR TITLE
A brief tsdoc pass

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -11,8 +11,8 @@ export class Emitter implements IEmitter {
   private chains = new Map<string, Chain>();
   private end: IDispatchNode | null = null;
 
-  public put({ type, payload }: IAction) {
-    const next: IDispatchNode = { type, payload, next: null };
+  public put(action: IAction) {
+    const next: IDispatchNode = { type: action.type, payload: action.payload, next: null };
     if (this.end !== null) {
       this.end = this.end.next = next;
     } else {
@@ -29,13 +29,9 @@ export class Emitter implements IEmitter {
     }
 
     chain.add(handler);
-  }
-
-  public off<T>(type: IActionType<T>, handler: (payload: T) => void) {
-    const chain = this.chains.get(type);
-    if (chain !== undefined) {
-      chain.remove(handler);
-    }
+    return () => {
+      chain!.remove(handler);
+    };
   }
 
   private drain() {

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -5,6 +5,12 @@ import { defer } from "./utils/defer";
 export class Store<S> implements IStore<S> {
   private chain = new Chain();
 
+  /**
+   * Constructs a Store with the given initial state and dispatch function.
+   *
+   * @param state initial state
+   * @param dispatch function called whenever a React component emits an Action using `dispatch()`
+   */
   constructor(public state: S, public dispatch: (action: IAction) => void) {}
   public getState() {
     return this.state;

--- a/src/defineAction.ts
+++ b/src/defineAction.ts
@@ -1,5 +1,10 @@
 import { IActionDefinition, IActionType } from "./types";
 
+/**
+ * Defines a new Action type for typesafe action handling.
+ *
+ * @param type the Action type string being defined
+ */
 export function defineAction<T = undefined>(type: string) {
   const definition: IActionDefinition<T> = ((payload: T) => ({ type, payload })) as any;
   definition.TYPE = type as IActionType<T>;

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -1,4 +1,4 @@
-import { IAction, IActionType, ICancelable, IEmitter } from "./types";
+import { IAction, IActionType, IEmitter } from "./types";
 
 /**
  * Equivalent to `emitter.on()`, exported as an Effect for consistency.
@@ -44,7 +44,7 @@ export function take<T>(
 ): Promise<T | null>;
 export function take<T>(emitter: IEmitter, type: IActionType<T>, maxWait?: number) {
   return new Promise<T | null>((resolve) => {
-    const o = once(emitter, type, (value) => {
+    const unsubscribe = once(emitter, type, (value) => {
       if (handle !== 0) {
         clearTimeout(handle);
       }
@@ -52,7 +52,7 @@ export function take<T>(emitter: IEmitter, type: IActionType<T>, maxWait?: numbe
       resolve(value);
     });
 
-    const handle = maxWait !== undefined ? setTimeout(o.cancel, maxWait) : 0;
+    const handle = maxWait !== undefined ? setTimeout(unsubscribe, maxWait) : 0;
   });
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { defineAction } from "./defineAction";
-export { off, on, once, put, take } from "./effects";
+export { on, once, put, take } from "./effects";
 export { Emitter } from "./Emitter";
 export { Store } from "./Store";
 export { IAction, IActionDefinition, IActionType, IEmitter, IStore } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,47 @@
+/**
+ * Variant of the standard Flux Standard Action type used by Tinysaga.
+ * When an Action is given to an Emitter, the handlers of the given `type`
+ * will be called with the action's `payload`.
+ *
+ * For constructing Actions to use with Tinysaga, prefer using ActionDefinitions
+ * created with `defineAction()`.
+ */
 export interface IAction {
+  /**
+   * Type of the action, like "ReloadUsers"
+   */
   type: string;
-  payload: unknown;
+
+  /**
+   * The payload associated with this action.
+   */
+  payload: any;
 }
 
+/**
+ * This class is a typesafe wrapper for creating Actions. Using `defineAction()`, consumers can
+ * create typesafe paylods by invoking the definition as a function.
+ *
+ * ```
+ * const LoadUser = defineAction<{ id: string }>("LoadUser");
+ * // the following line is typesafe
+ * dispatch(LoadUser({ id: "4" }));
+ * ```
+ */
 export type IActionDefinition<T> = {
+  /**
+   * The Action type string, used for registering handlers via Emitter.on()
+   */
   TYPE: IActionType<T>;
+
+  /**
+   * Convenience TypeScript type for higher order type arithmetic
+   */
   __payload: T;
+
+  /**
+   * Constructs an instance of this Action using the definition's `type` and this `payload`
+   */
   (payload: T): { type: string; payload: T };
 } & (T extends undefined
   ? {
@@ -17,17 +53,78 @@ export type IActionType<T> = string & {
   __payload: T;
 };
 
+/**
+ * An event bus in Tinysaga which accepts `{ type, payload }` Actions
+ * and invokes all listeners of the given `type` with the `payload`.
+ *
+ * Note: The Tinysaga emitter operates as a _strict_ event queue, which means
+ * emitting Actions from a previous listener being called will *enqueue the action for
+ * later processing*, rather than allowing reentrant action loop processing.
+ *
+ * This design choice was made specifically to avoid two different listeners seeing the same
+ * events in different orders. If your workflow requires reentrant event processing, consider rewriting your code
+ * to not rely on the special ordering or managing your own eventing structure for those needs.
+ *
+ * For constructing an emitter, use the Emitter class.
+ */
 export interface IEmitter {
+  /**
+   * Emits a new Action onto this emitter. If the emitter is already notifying listeners
+   * of a previous Action, this followup `action` will be added to a queue for later processing.
+   *
+   * @param action the action to emit
+   */
   put(action: IAction): void;
-  on<T>(type: IActionType<T>, handler: (payload: T) => void): void;
-  off<T>(type: IActionType<T>, handler: (payload: T) => void): void;
+
+  /**
+   * Listens for Actions of a given Type to enter the emitter, invoking the given callback
+   * with the Action's payload. Returns a cleanup function that, when called, will stop
+   * notifying the handler of further Actions, similar to Store.subscribe() in Redux.
+   *
+   * @param type
+   * @param handler
+   */
+  on<T>(type: IActionType<T>, handler: (payload: T) => void): () => void;
 }
 
+/**
+ * A Store type included with Tinysaga. This Store can be handed directly to React-Redux
+ * and will completely replace the Redux needs of some applications.
+ *
+ * For constructing a store, use the Store class.
+ */
 export interface IStore<S> {
+  /**
+   * Ths state of the store. Applications should feel free to reference this value directly,
+   * rather than using getState().
+   */
   readonly state: S;
 
+  /**
+   * The state of the store as a getter function, required for React-Redux integration.
+   */
   getState(): S;
+
+  /**
+   * Directly sets the new state of the store. If this state reference is different from the old one,
+   * listeners will be notified on the next tick. If you'd like to notify listeners sooner (e.g. to
+   * _synchronously_ repaint your UI), use store.flush() immediately after store.setState().
+   */
   setState(nextState: S): void;
+
+  /**
+   * Subscribes to changes from this store, required for React-Redux integrations. Applications
+   * should generally not need to subscribe() to the Store, preferring instead to handle
+   * update logic as part of their Emitter handler logic.
+   *
+   * @param cb
+   */
   subscribe(cb: () => void): () => void;
+
+  /**
+   * Flushes any pending listener notifications synchronously, rather than waiting until the next tick.
+   * The default behavior to wait a tick is to prevent multiple synchronous repaints to the same Redux tree,
+   * e.g. if two different handlers for an Action both wrote to the same Store.
+   */
   flush(): void;
 }


### PR DESCRIPTION
Adds some internal tsdoc comments for the major exported symbols.

Also removes `off()` and `ICancelable` variants in favor of consistency with Redux. All functions which require cleanup now return a cleanup callback `() => void`.