### PR TITLE
Add takeEvery() effect for similarity to redux-saga

### DIFF
--- a/src/effects.ts
+++ b/src/effects.ts
@@ -67,6 +67,17 @@ export function take<T>(emitter: IEmitter, type: IActionType<T>, maxWait?: numbe
 }
 
 /**
+ * Equivalent to `emitter.on()`, exported as an Effect for consistency.
+ *
+ * @param emitter the emitter to hook into
+ * @param type the action type to listen on
+ * @param cb a callback called whenever the action is emitted
+ */
+export function takeEvery<T>(emitter: IEmitter, type: IActionType<T>, cb: (t: T) => void) {
+  return emitter.on(type, cb);
+}
+
+/**
  *
  * Equivalent to `emitter.put()`, exported as an Effect for consistency.
  *

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { defineAction } from "./defineAction";
-export { on, once, put, take } from "./effects";
+export { on, once, put, take, takeEvery } from "./effects";
 export { Emitter } from "./Emitter";
 export { Store } from "./Store";
 export { IAction, IActionDefinition, IActionType, IEmitter, IStore } from "./types";


### PR DESCRIPTION
This PR introduces another alias for `emitter.on()` in `takeEvery()`, which can be used analogously to `takeEvery()` in redux-thunk.