### PR TITLE
Rename `Emitter` to `Channel` for consistency with redux-saga

### DIFF
--- a/src/Emitter.ts
+++ b/src/Emitter.ts
@@ -1,4 +1,4 @@
-import { IAction, IActionType, IEmitter } from "./types";
+import { IAction, IActionType, IChannel } from "./types";
 import { Chain } from "./utils/Chain";
 
 interface IDispatchNode {
@@ -7,7 +7,7 @@ interface IDispatchNode {
   next: IDispatchNode | null;
 }
 
-export class Emitter implements IEmitter {
+export class Channel implements IChannel {
   private chains = new Map<string, Chain>();
   private end: IDispatchNode | null = null;
 

--- a/src/effects.ts
+++ b/src/effects.ts
@@ -1,4 +1,4 @@
-import { IAction, IActionType, IEmitter } from "./types";
+import { IAction, IActionType, IChannel } from "./types";
 
 const TRUE_PREDICATE = () => true;
 
@@ -9,7 +9,7 @@ const TRUE_PREDICATE = () => true;
  * @param type the action type to listen on
  * @param cb a callback called whenever the action is emitted
  */
-export function on<T>(emitter: IEmitter, type: IActionType<T>, cb: (t: T) => void) {
+export function on<T>(emitter: IChannel, type: IActionType<T>, cb: (t: T) => void) {
   return emitter.on(type, cb);
 }
 
@@ -21,7 +21,7 @@ export function on<T>(emitter: IEmitter, type: IActionType<T>, cb: (t: T) => voi
  * @param type the action type to listen on
  * @param cb a callback called exactly once when the next action is emitted
  */
-export function once<T>(emitter: IEmitter, type: IActionType<T>, cb: (t: T) => void) {
+export function once<T>(emitter: IChannel, type: IActionType<T>, cb: (t: T) => void) {
   const destroy = emitter.on(type, (value: T) => {
     destroy();
     cb(value);
@@ -38,7 +38,7 @@ export function once<T>(emitter: IEmitter, type: IActionType<T>, cb: (t: T) => v
  * @param emitter emitter to hook into
  * @param type the action type to listen on
  */
-export function take<T>(emitter: IEmitter, type: IActionType<T>): Promise<T>;
+export function take<T>(emitter: IChannel, type: IActionType<T>): Promise<T>;
 
 /**
  * Returns a promise whose resolved value will be the next action of the given type
@@ -50,7 +50,7 @@ export function take<T>(emitter: IEmitter, type: IActionType<T>): Promise<T>;
  * @param maxWait the maximum time, in millis, to wait for the given action type
  */
 export function take<T>(
-  emitter: IEmitter,
+  emitter: IChannel,
   type: IActionType<T>,
   maxWait: number,
 ): Promise<T | null>;
@@ -65,14 +65,14 @@ export function take<T>(
  * @param maxWait the maximum time, in millis, to wait for the given action type
  */
 export function take<T>(
-  emitter: IEmitter,
+  emitter: IChannel,
   type: IActionType<T>,
   filter: (payload: T) => boolean,
   maxWait: number,
 ): Promise<T | null>;
 
 export function take<T>(
-  emitter: IEmitter,
+  emitter: IChannel,
   type: IActionType<T>,
   arg2?: number | Function, // tslint:disable-line:ban-types
   arg3?: number,
@@ -108,7 +108,7 @@ export function take<T>(
  * @param type the action type to listen on
  * @param cb a callback called whenever the action is emitted
  */
-export function takeEvery<T>(emitter: IEmitter, type: IActionType<T>, cb: (t: T) => void) {
+export function takeEvery<T>(emitter: IChannel, type: IActionType<T>, cb: (t: T) => void) {
   return emitter.on(type, cb);
 }
 
@@ -119,6 +119,6 @@ export function takeEvery<T>(emitter: IEmitter, type: IActionType<T>, cb: (t: T)
  * @param emitter the emitter to use
  * @param action the action to emit
  */
-export function put(emitter: IEmitter, action: IAction) {
+export function put(emitter: IChannel, action: IAction) {
   emitter.put(action);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { defineAction } from "./defineAction";
 export { on, once, put, take, takeEvery } from "./effects";
-export { Emitter } from "./Emitter";
+export { Channel as Emitter } from "./Emitter";
 export { Store } from "./Store";
-export { IAction, IActionDefinition, IActionType, IEmitter, IStore } from "./types";
+export { IAction, IActionDefinition, IActionType, IChannel as IEmitter, IStore } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,7 +67,7 @@ export type IActionType<T> = string & {
  *
  * For constructing an emitter, use the Emitter class.
  */
-export interface IEmitter {
+export interface IChannel {
   /**
    * Emits a new Action onto this emitter. If the emitter is already notifying listeners
    * of a previous Action, this followup `action` will be added to a queue for later processing.


### PR DESCRIPTION
This is just a cosmetic rename, but it brings it closer to redux-saga which is a good thing for familiarity.