### PR TITLE
Guarantee that put() is never synchronous

### DIFF
--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -1,51 +1,71 @@
 import { IAction, IActionType, IChannel } from "./types";
-import { ListenerList } from "./utils/Chain";
+import { defer } from "./utils/defer";
+import { ListenerList } from "./utils/ListenerList";
+import { noop } from "./utils/noop";
 
-interface IDispatchNode {
-  type: string;
-  payload: any;
-  next: IDispatchNode | null;
+export interface IChannelOpts {
+  afterEmpty?: () => void;
+}
+
+class Node {
+  public next: Node | null = null;
+  constructor(public type: string, public payload: unknown) {}
+}
+
+const enum Status {
+  IDLE,
+  SCHEDULED,
+  DRAINING,
 }
 
 export class Channel implements IChannel {
-  private chains = new Map<string, ListenerList>();
-  private end: IDispatchNode | null = null;
+  private eventLists = new Map<string, ListenerList>();
+  private status = Status.IDLE;
+  private end: Node | null = null;
+  private afterEmpty: () => void;
 
-  constructor(private
+  constructor(opts: IChannelOpts = {}) {
+    this.afterEmpty = opts.afterEmpty ?? noop;
+  }
+
   public put(action: IAction) {
-    const next: IDispatchNode = { type: action.type, payload: action.payload, next: null };
     if (this.end !== null) {
-      this.end = this.end.next = next;
+      this.end.next = new Node(action.type, action.payload);
+      this.end = this.end.next;
     } else {
-      this.end = next;
-      this.drain();
+      this.end = new Node(action.type, action.payload);
+    }
+
+    if (this.status === Status.IDLE) {
+      this.status = Status.SCHEDULED;
+      this.drainDefer();
     }
   }
 
   public on<T>(type: IActionType<T>, handler: (payload: T) => void) {
-    let chain = this.chains.get(type);
-    if (chain === undefined) {
-      chain = new ListenerList();
-      this.chains.set(type, chain);
+    let list = this.eventLists.get(type);
+    if (list === undefined) {
+      list = new ListenerList();
+      this.eventLists.set(type, list);
     }
 
-    chain.add(handler);
-    return () => {
-      chain!.remove(handler);
-    };
+    return list.add(handler);
   }
 
-  private drain() {
-    let node: IDispatchNode | null = this.end;
-    while (node !== null) {
-      const chain = this.chains.get(node.type);
+  private drainDefer = defer(() => {
+    this.status = Status.DRAINING;
+    let iter = this.end;
+    while (iter !== null) {
+      const chain = this.eventLists.get(iter.type);
       if (chain !== undefined) {
-        chain.emit(node.payload);
+        chain.emit(iter.payload);
       }
 
-      node = node.next;
+      iter = iter.next;
     }
 
     this.end = null;
-  }
+    this.status = Status.IDLE;
+    this.afterEmpty();
+  });
 }

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -1,5 +1,5 @@
 import { IAction, IActionType, IChannel } from "./types";
-import { Chain } from "./utils/Chain";
+import { ListenerList } from "./utils/Chain";
 
 interface IDispatchNode {
   type: string;
@@ -8,9 +8,10 @@ interface IDispatchNode {
 }
 
 export class Channel implements IChannel {
-  private chains = new Map<string, Chain>();
+  private chains = new Map<string, ListenerList>();
   private end: IDispatchNode | null = null;
 
+  constructor(private
   public put(action: IAction) {
     const next: IDispatchNode = { type: action.type, payload: action.payload, next: null };
     if (this.end !== null) {
@@ -24,7 +25,7 @@ export class Channel implements IChannel {
   public on<T>(type: IActionType<T>, handler: (payload: T) => void) {
     let chain = this.chains.get(type);
     if (chain === undefined) {
-      chain = new Chain();
+      chain = new ListenerList();
       this.chains.set(type, chain);
     }
 

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -1,10 +1,10 @@
 import { IAction, IStore } from "./types";
-import { ListenerList } from "./utils/Chain";
 import { defer } from "./utils/defer";
+import { ListenerList } from "./utils/ListenerList";
 import { noop } from "./utils/noop";
 
 export class Store<S> implements IStore<S> {
-  private chain = new ListenerList();
+  private listeners = new ListenerList();
 
   /**
    * Constructs a Store with the given initial state and dispatch function.
@@ -26,8 +26,7 @@ export class Store<S> implements IStore<S> {
   }
 
   public subscribe(cb: () => void) {
-    this.chain.add(cb);
-    return () => this.chain.remove(cb);
+    return this.listeners.add(cb);
   }
 
   public flush() {
@@ -35,6 +34,6 @@ export class Store<S> implements IStore<S> {
   }
 
   private notifySubscribers = defer(() => {
-    this.chain.emit();
+    this.listeners.emit(null);
   });
 }

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -1,13 +1,10 @@
 import { IAction, IStore } from "./types";
-import { Chain } from "./utils/Chain";
+import { ListenerList } from "./utils/Chain";
 import { defer } from "./utils/defer";
-
-function noop() {
-  // noop
-}
+import { noop } from "./utils/noop";
 
 export class Store<S> implements IStore<S> {
-  private chain = new Chain();
+  private chain = new ListenerList();
 
   /**
    * Constructs a Store with the given initial state and dispatch function.
@@ -15,11 +12,7 @@ export class Store<S> implements IStore<S> {
    * @param state initial state
    * @param dispatch function called whenever a React component emits an Action using `dispatch()`
    */
-  constructor(
-    public state: S,
-    public dispatch: (action: IAction) => void = noop,
-    private afterFlush = noop,
-  ) {}
+  constructor(public state: S, public dispatch: (action: IAction) => void = noop) {}
 
   public getState() {
     return this.state;
@@ -42,7 +35,6 @@ export class Store<S> implements IStore<S> {
   }
 
   private notifySubscribers = defer(() => {
-    this.chain.emit(undefined);
-    this.afterFlush();
+    this.chain.emit();
   });
 }

--- a/src/utils/collectionUtils.ts
+++ b/src/utils/collectionUtils.ts
@@ -1,0 +1,6 @@
+export function pull<T>(arr: T[], value: T) {
+  const idx = arr.indexOf(value);
+  if (idx !== -1) {
+    arr.splice(idx, 1);
+  }
+}

--- a/src/utils/collectionUtils.ts
+++ b/src/utils/collectionUtils.ts
@@ -4,3 +4,10 @@ export function pull<T>(arr: T[], value: T) {
     arr.splice(idx, 1);
   }
 }
+
+export function replaceFirst<T>(arr: T[], value: T, nextValue: T) {
+  const idx = arr.indexOf(value);
+  if (idx !== -1) {
+    arr[idx] = nextValue;
+  }
+}

--- a/src/utils/noop.ts
+++ b/src/utils/noop.ts
@@ -1,0 +1,3 @@
+export function noop() {
+  // noop
+}

--- a/tslint.json
+++ b/tslint.json
@@ -7,6 +7,7 @@
     "callable-types": false,
     "prefer-for-of": false,
     "member-access": true,
+    "max-classes-per-file": false,
     "no-implicit-dependencies": [
       true,
       "dev"


### PR DESCRIPTION
Refactors Channel so that its `put()` method is _never_ synchronous. This should normalize interaction patterns around channels, where e.g. it's always safe to `put()` and then `await take()`.