### PR TITLE
Set sideEffects: false in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "lib/index.js",
   "module": "esm/index.js",
   "typings": "esm/index.js",
+  "sideEffects": false,
   "scripts": {
     "build": "yarn build:commonjs && yarn build:esm",
     "build:commonjs": "tsc",


### PR DESCRIPTION
Modern es6 toolchains want to tree-shake unused code, so we need to tell these tools that it's safe to do so.